### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.harrison</groupId>
 	<artifactId>insight-plugin-mongodb</artifactId>
@@ -20,12 +20,12 @@
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</repository>
 		<repository>
 			<id>spring-milestone</id>
 			<name>Spring Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 	</repositories>
 

--- a/src/main/resources/META-INF/insight-plugin-mongodb.xml
+++ b/src/main/resources/META-INF/insight-plugin-mongodb.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:insight="http://www.springframework.org/schema/insight-idk"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
 	<insight:plugin name="mongodb" version="${project.version}"
 		publisher="Stephen Harrison (stephen@harrison.org) and the Insight Team" />

--- a/src/test/resources/META-INF/test-app-context.xml
+++ b/src/test/resources/META-INF/test-app-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
     <!--
         This Spring application context is only used in testing scenarios to setup the FreeMarker configuration. When
         the plugin is deployed within Spring Insight, this will already be provided.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/beans/spring-beans-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd ([https](https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://maven.springframework.org/milestone with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release with 1 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/beans with 4 occurrences
* http://www.springframework.org/schema/insight-idk with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences