### PR TITLE
URL Cleanup

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,6 +1,6 @@
 h1. This is a MongoDB plugin for Spring Insight
 
-Spring Insight runs in the SpringSource tc Server. See http://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use MongoDB (http://www.mongodb.org) through the MongoDB Java driver, which typically works outside the normal ORM flow. 
+Spring Insight runs in the SpringSource tc Server. See https://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use MongoDB (https://www.mongodb.org) through the MongoDB Java driver, which typically works outside the normal ORM flow. 
 
 h2. What does it do?
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.mongodb.org with 1 occurrences migrated to:  
  https://www.mongodb.org ([https](https://www.mongodb.org) result 301).
* [ ] http://www.springsource.org/insight with 1 occurrences migrated to:  
  https://www.springsource.org/insight ([https](https://www.springsource.org/insight) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/insight with 1 occurrences